### PR TITLE
update : subscribe와 publish할때, type값을 받을수있도록 추가,

### DIFF
--- a/src/main/java/com/example/mentoringproject/notification/notification/controller/NotificationController.java
+++ b/src/main/java/com/example/mentoringproject/notification/notification/controller/NotificationController.java
@@ -3,7 +3,7 @@ package com.example.mentoringproject.notification.notification.controller;
 import static com.example.mentoringproject.common.util.SpringSecurityUtil.getLoginEmail;
 
 import com.example.mentoringproject.notification.notification.model.NotificationRequestDto;
-import com.example.mentoringproject.notification.notification.model.NotificationResponseDto;
+import com.example.mentoringproject.notification.notification.model.NotificationDto;
 import com.example.mentoringproject.notification.notification.service.NotificationService;
 import com.example.mentoringproject.notification.redis.RedisPublisher;
 import io.swagger.v3.oas.annotations.Operation;
@@ -62,10 +62,10 @@ public class NotificationController {
 
   @Operation(summary = "알림 목록 조회 api", description = "나에게온 알림 최신순으로 10개씩 목록 조회", responses = {
       @ApiResponse(responseCode = "200", description = "대상자에게 알림 푸쉬", content =
-      @Content(schema = @Schema(implementation = NotificationResponseDto.class)))
+      @Content(schema = @Schema(implementation = NotificationDto.class)))
   })
   @GetMapping("/notification")
-  public ResponseEntity<Page<NotificationResponseDto>> getNotification(
+  public ResponseEntity<Page<NotificationDto>> getNotification(
       @PageableDefault(sort = "registerDate", direction = Sort.Direction.DESC) Pageable pageable
   ) {
     String email = getLoginEmail();
@@ -74,11 +74,11 @@ public class NotificationController {
 
   @Operation(summary = "알림 읽기 api", description = "알림 읽기", responses = {
       @ApiResponse(responseCode = "200", description = "알림 읽음", content =
-      @Content(schema = @Schema(implementation = NotificationResponseDto.class)))
+      @Content(schema = @Schema(implementation = NotificationDto.class)))
   })
 
   @PutMapping("/read/notification")
-  public ResponseEntity<NotificationResponseDto> readNotification(@RequestParam("notificationId") @Min(1) Long notificationId) {
+  public ResponseEntity<NotificationDto> readNotification(@RequestParam("notificationId") @Min(1) Long notificationId) {
     return ResponseEntity.ok(notificationService.readNotification(notificationId));
   }
 

--- a/src/main/java/com/example/mentoringproject/notification/notification/model/NotificationConnectionType.java
+++ b/src/main/java/com/example/mentoringproject/notification/notification/model/NotificationConnectionType.java
@@ -1,0 +1,5 @@
+package com.example.mentoringproject.notification.notification.model;
+
+public enum NotificationConnectionType {
+  SUBSCRIBE, RECEIVE
+}

--- a/src/main/java/com/example/mentoringproject/notification/notification/model/NotificationDto.java
+++ b/src/main/java/com/example/mentoringproject/notification/notification/model/NotificationDto.java
@@ -1,0 +1,48 @@
+package com.example.mentoringproject.notification.notification.model;
+
+import com.example.mentoringproject.notification.notification.entity.Notification;
+import com.example.mentoringproject.notification.notification.entity.NotificationType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.data.domain.Page;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class NotificationDto {
+
+
+  private Long notificationId;
+  private String receiverEmail;
+  private String content;
+  private Boolean isRead;
+  private NotificationType notificationType;
+  private String registerDate;
+
+  public static NotificationDto from(Notification notification) {
+    return NotificationDto.builder()
+        .notificationId(notification.getId())
+        .receiverEmail(notification.getReceiverEmail())
+        .content(notification.getContent())
+        .isRead(notification.getIsRead())
+        .notificationType(notification.getNotificationType())
+        .registerDate(String.valueOf(notification.getRegisterDate()))
+        .build();
+  }
+
+  public static Page<NotificationDto> from(Page<Notification> notificationPage) {
+    return notificationPage.map(
+        notification -> NotificationDto.builder()
+            .notificationId(notification.getId())
+            .receiverEmail(notification.getReceiverEmail())
+            .content(notification.getContent())
+            .isRead(notification.getIsRead())
+            .registerDate(String.valueOf(notification.getRegisterDate()))
+            .build());
+  }
+}

--- a/src/main/java/com/example/mentoringproject/notification/notification/model/NotificationFinalDto.java
+++ b/src/main/java/com/example/mentoringproject/notification/notification/model/NotificationFinalDto.java
@@ -1,5 +1,7 @@
 package com.example.mentoringproject.notification.notification.model;
 
+
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -11,9 +13,11 @@ import lombok.Setter;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class NotificationResponseDto {
+public class NotificationFinalDto {
 
+  @Schema(description = "NotificationType", example = "SUBSCRIBE/RECEIVE")
   private NotificationConnectionType type;
-  private NotificationDto data;
+  @Schema(description = "공지 데이터", example = "Json형식의 데이터")
+  private Object data;
 
 }

--- a/src/main/java/com/example/mentoringproject/notification/redis/RedisPublisher.java
+++ b/src/main/java/com/example/mentoringproject/notification/redis/RedisPublisher.java
@@ -1,6 +1,7 @@
 package com.example.mentoringproject.notification.redis;
 
 import com.example.mentoringproject.notification.notification.model.NotificationRequestDto;
+import com.example.mentoringproject.notification.notification.model.NotificationDto;
 import com.example.mentoringproject.notification.notification.model.NotificationResponseDto;
 import com.example.mentoringproject.notification.notification.service.NotificationService;
 import lombok.AllArgsConstructor;

--- a/src/main/java/com/example/mentoringproject/notification/redis/RedisSubscriber.java
+++ b/src/main/java/com/example/mentoringproject/notification/redis/RedisSubscriber.java
@@ -1,6 +1,7 @@
 package com.example.mentoringproject.notification.redis;
 
 import com.example.mentoringproject.common.exception.AppException;
+import com.example.mentoringproject.notification.notification.model.NotificationDto;
 import com.example.mentoringproject.notification.notification.model.NotificationResponseDto;
 import com.example.mentoringproject.notification.notification.service.NotificationService;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -24,10 +25,10 @@ public class RedisSubscriber implements MessageListener {
   public void onMessage(Message message, byte[] pattern) {
 
     try {
-      NotificationResponseDto notificationDto = objectMapper.readValue(message.getBody(),
+      NotificationResponseDto notificationResponseDto = objectMapper.readValue(message.getBody(),
           NotificationResponseDto.class);
-      log.debug("send message to sseUser, message= {}", notificationDto);
-      notificationService.send(notificationDto);
+      log.debug("send message to sseUser, message= {}", notificationResponseDto);
+      notificationService.send(notificationResponseDto);
     } catch (IOException e) {
       throw new AppException(HttpStatus.INTERNAL_SERVER_ERROR, e.getMessage());
     }


### PR DESCRIPTION
type값은 SUBSCRIBE, RECEIVE 두가지 타입
데이터는 Json값으로 전송되도록 수정

### 변경사항

**AS-IS**(작업한 부분)
- subscribe와 publish 할때 requestBody값수정
- type과 data값으로 받을 수 있도록 수정
```
{
  type: "RECEIVE",
  data: {
    "notificationId": 0,
    "receiverEmail": "string",
    "content": "string",
    "isRead": true,
    "notificationType": "PAY",
    "registerDate": "string"
  }
}
```
type 값은 RECEIVE와 SUBSCRIBE 두가지로 설정

**Comment**(설명, 코멘트 => 안적으셔도 됩니다.)

### 테스트
- [x] API 테스트 